### PR TITLE
README first line change made change to avoid confusion with Public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # frontend
-A GraphQL frontend to the demo app
+React UI that interacts with GraphQL public api
 
 [![CircleCI](https://circleci.com/gh/hashicorp-demoapp/frontend.svg?style=svg)](https://circleci.com/gh/hashicorp-demoapp/frontend)  
 


### PR DESCRIPTION
Docs change to avoid confusion around the public api and the ui and clearly state this is where React is. This will change the README but won't change the About section I don't think. That may need to be changed by the owner. 