### PR TITLE
update circleci workflow to build the demo app as multi arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,22 +35,46 @@ jobs:
       - image: circleci/golang:1.13
     environment:
       GO111MODULE: "on"
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64
     working_directory: ~/github.com/hashicorpdemoapp/frontend
     steps:
       - setup_remote_docker
       - attach_workspace:
           at: ~/github.com/hashicorpdemoapp
       - run:
+          name: install docker buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64"
+
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+
+            mkdir -p ~/.docker/cli-plugins
+
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+            docker buildx install
+
+            # Run binfmt
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+
+            docker context create multi_arch_build
+
+            # Create Builder
+            docker buildx create --use multi_arch_build
+      - run:
           name: docker login
           command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
       - run:
-          name: docker build
+          name: docker buildx build and push
           command: |
-            docker build -t hashicorpdemoapp/frontend:latest -t hashicorpdemoapp/frontend:${CIRCLE_TAG} .
-      - run:
-          name: docker push
-          command: |
-            docker push hashicorpdemoapp/frontend
+            docker buildx build --platform linux/amd64,linux/arm64 \
+              -t hashicorpdemoapp/frontend:${CIRCLE_TAG} \
+              --push \
+              .
   
   publish-github-release:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.0.1
+VERSION=v0.0.5
 REPOSITORY=hasicorpdemoapp/frontend
 
 build_docker:


### PR DESCRIPTION
I also tested the full tutorial at https://learn.hashicorp.com/tutorials/consul/service-mesh-deploy?in=consul/gs-consul-service-mesh with the new images @joatmon08 put up for the `product-api-db` and the `product-api` as well as with the `public-api` and this one.  They all are working on both M1 and Intel.