### PR TITLE
Graceful fallback for missing coffee props

### DIFF
--- a/src/components/CartButton.js
+++ b/src/components/CartButton.js
@@ -4,10 +4,10 @@ export default function CartButton(props) {
   const isVault = props.id == 3
 
   return (
-    <button className={`${isVault ? 'text-black' : 'text-white'} relative flex xs:w-1/2 items-center justify-center h-[72px] px-2 text-left rounded-lg shadow-low group transition duration-500 ease-in-out overflow-hidden translate-x-0`} onClick={props.action} style={{ backgroundColor: `${props.coffee.color}` }}>
+    <button className={`${isVault ? 'text-black' : 'text-white'} relative flex xs:w-1/2 items-center justify-center h-[72px] px-2 text-left rounded-lg shadow-low group transition duration-500 ease-in-out overflow-hidden translate-x-0`} onClick={props.action} style={{ backgroundColor: `${props.coffee.color != '' ? props.coffee.color : '#333'}` }}>
       <span className="absolute inset-0 opacity-0 group-hover:opacity-100 bg-black/20 transition duration-500 ease-in-out rounded-lg mix-blend-overlay"></span>
       <span className="absolute left-0 top-0 bottom-0 w-1/2 bg-gradient-to-r from-white/0 via-white/20 to-white/0 shimmer"></span>
-      <span className="relative uppercase tracking-widest text-md lg:text-lg">Add {props.amount > 1 && (<span className={`${isVault ? 'bg-black' : 'bg-white'} rounded-full pl-2 pr-1.5 py-0.5`} style={{ color: `${props.coffee.color}` }}>{props.amount}</span>)} to cart</span>
+      <span className="relative uppercase tracking-widest text-md lg:text-lg">Add {props.amount > 1 && (<span className={`${isVault ? 'bg-black' : 'bg-white'} rounded-full pl-2 pr-1.5 py-0.5`} style={{ color: `${props.coffee.color != '' ? props.coffee.color : '#333'}` }}>{props.amount}</span>)} to cart</span>
     </button>
   )
 }

--- a/src/pages/coffee/[id].js
+++ b/src/pages/coffee/[id].js
@@ -111,9 +111,21 @@ export default function Coffee() {
                   <div className="flex flex-col md:px-8">
                     <dl className="grid sm:grid-cols-3">
                       <dt className="text-black/75 dark:text-white/75 text-sm sm:border-b border-gray-200 dark:border-white/10 sm:py-2 pt-2 sm:pt-3">Collection</dt>
-                      <dd className="text-lg col-span-2 border-b border-gray-200 dark:border-white/10 py-2 pt-0 sm:pt-2">{coffee.collection}</dd>
+                      <dd className="text-lg col-span-2 border-b border-gray-200 dark:border-white/10 py-2 pt-0 sm:pt-2">
+                        {coffee.collection != '' ? (
+                          <span>{coffee.collection}</span>
+                        ) : (
+                          <span className="italic opacity-40">Unavailable</span>
+                        )}
+                      </dd>
                       <dt className="text-black/75 dark:text-white/75 text-sm sm:border-b border-gray-200 dark:border-white/10 sm:py-2 pt-4 sm:pt-3">Origin</dt>
-                      <dd className="text-lg col-span-2 border-b border-gray-200 dark:border-white/10 py-2 pt-0 sm:pt-2">{coffee.origin}</dd>
+                      <dd className="text-lg col-span-2 border-b border-gray-200 dark:border-white/10 py-2 pt-0 sm:pt-2">
+                        {coffee.origin != '' ? (
+                          <span>{coffee.origin}</span>
+                        ) : (
+                          <span className="italic opacity-40">Unavailable</span>
+                        )}
+                      </dd>
                       <dt className="text-black/75 dark:text-white/75 text-sm sm:py-2 pt-4 sm:pt-3">Ingredients</dt>
                       <dd className="col-span-2 py-2 pt-2.5">
                         {ingredients && ingredients.map((ingredient, index) => (


### PR DESCRIPTION
This will address the issue @karl-cardenas-coding reported:

### Before
<img width="459" alt="CleanShot 2022-03-23 at 09 51 03@2x" src="https://user-images.githubusercontent.com/717867/159671733-9d550c09-9151-486c-bc64-5b01255a72f2.png">

### After
<img width="1130" alt="CleanShot 2022-03-23 at 09 57 36@2x" src="https://user-images.githubusercontent.com/717867/159672960-1f7a5c1a-3cca-4a64-9dfe-aa59e15e1c91.png">

There are now fallbacks for when `coffee.collection`, `coffee.origin` and `coffee.color` return blank data.

@karl-cardenas-coding I think what happened here is that the API version that was being used for that particular demo instance was old (or at least the product data was). If the API doesn't return `coffee.color` then the button wouldn't have a color, and if `coffee.collection` and `coffee.origin` don't have values they'd be missing in the UI too. All 3 of those properties were added in the redesign, which makes me think that this is running an old version of the API!