### PR TITLE
Add footer flag to frontend application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v1.0.1
+VERSION=v1.0.4
 REPOSITORY=hashicorpdemoapp/frontend
 
 build_docker:

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -32,7 +32,7 @@ export default function Footer() {
       </aside>
       <div className="flex justify-center w-screen bg-gray-100/50 dark:bg-black/50 py-8 shadow-mid dark:shadow-highlight">
         <div className="flex flex-col space-y-4 xs:space-y-0 xs:flex-row items-center justify-between max-w-[1080px] px-8 w-full">
-          <p className="text-sm text-black/75 dark:text-white/75">{Copyright()}. <span className="opacity-50">All rights reserved.</span></p>
+          <p className="text-sm text-black/75 dark:text-white/75">{Copyright()}. <span className="opacity-50">All rights reserved. {FooterFlag()}</span></p>
           <Theme />
         </div>
       </div>
@@ -58,4 +58,8 @@ function Copyright() {
   let year = newDate.getFullYear();
 
   return `© ${year} HashiCorp`
+}
+
+function FooterFlag() {
+  return process.env.NEXT_PUBLIC_FOOTER_FLAG
 }


### PR DESCRIPTION
This PR creates a feature flag for the footer. This allows you to modify the frontend at run time with environment variables.

For example, the following command will produce the image below.

```
NEXT_PUBLIC_FOOTER_FLAG="Footer Flag 123." yarn dev
```

![image](https://user-images.githubusercontent.com/7556325/163916134-8acfedb6-5f6f-457a-b820-31d381d34cee.png)
