### PR TITLE
Fix footer flag env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
 # ENV NEXT_TELEMETRY_DISABLED 1
-RUN NEXT_PUBLIC_PUBLIC_API_URL=APP_NEXT_PUBLIC_API_URL yarn build
+RUN NEXT_PUBLIC_PUBLIC_API_URL=APP_NEXT_PUBLIC_API_URL NEXT_PUBLIC_FOOTER_FLAG=APP_PUBLIC_FOOTER_FLAG yarn build
 
 # Production image, copy all the files and run next
 FROM node:16-alpine AS runner

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,10 @@ test -n "$NEXT_PUBLIC_PUBLIC_API_URL"
 
 find /app/.next \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s#APP_NEXT_PUBLIC_API_URL#$NEXT_PUBLIC_PUBLIC_API_URL#g"
 
+echo "Checking for NEXT_PUBLIC_FOOTER_FLAG env var"
+test -n "$NEXT_PUBLIC_FOOTER_FLAG"
+
+find /app/.next \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s#APP_PUBLIC_FOOTER_FLAG#$NEXT_PUBLIC_FOOTER_FLAG#g"
+
 echo "Starting HashiCups Frontend"
 exec "$@"


### PR DESCRIPTION
Forgot to push this final commit

---

This PR creates a feature flag for the footer. This allows you to modify the frontend at run time with environment variables.

For example, the following command will produce the image below.

```
NEXT_PUBLIC_FOOTER_FLAG="Footer Flag 123." yarn dev
```

![image](https://user-images.githubusercontent.com/7556325/163916134-8acfedb6-5f6f-457a-b820-31d381d34cee.png)
