### PR TITLE
Update to allow CORS

### DIFF
--- a/src/gql/apolloClient.js
+++ b/src/gql/apolloClient.js
@@ -8,6 +8,9 @@ if (publicApiUrl === "/") publicApiUrl = ""
 
 const httpLink = createHttpLink({
   uri: `${publicApiUrl}/api`,
+  fetchOptions: {
+    mode: 'no-cors',
+  },
 })
 
 const authLink = setContext((_, { headers }) => {


### PR DESCRIPTION
This lets you call the API directly from the frontend (rather than requiring NGINX)