### PR TITLE
Remove no-cors option from Apollo client config to work around apollographql/apollo-link#275

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v1.0.5
+VERSION=v1.0.6
 REPOSITORY=hashicorpdemoapp/frontend
 
 build_docker:

--- a/src/gql/apolloClient.js
+++ b/src/gql/apolloClient.js
@@ -8,9 +8,6 @@ if (publicApiUrl === "/") publicApiUrl = ""
 
 const httpLink = createHttpLink({
   uri: `${publicApiUrl}/api`,
-  fetchOptions: {
-    mode: 'no-cors',
-  },
 })
 
 const authLink = setContext((_, { headers }) => {


### PR DESCRIPTION
Tested with my own Docker repo and this worked connecting to public-api on a separate EC2 instance.  @im2nguyen